### PR TITLE
additionall executable for integration with agda, some touchups of parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist-*
 newdist
 .DS_Store
+TAGS

--- a/app/MainStd.hs
+++ b/app/MainStd.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Main where
+
+import System.CPUTime
+import qualified System.Timeout as T
+import Options.Applicative
+
+import Parser
+import AgdaShow
+import Solver
+
+import CellContext
+import qualified Data.Attoparsec.Text as A
+
+import qualified Data.Text.IO as TIO
+import System.IO
+import qualified Data.Text as T
+
+data Session = Session
+  { file      :: String
+  , verbose   :: Bool
+  , timeout :: Int }
+
+main :: IO ()
+main = do
+  contents <- TIO.hGetContents stdin
+  let parsed = A.parseOnly fileParser contents
+  case parsed of
+    Right (ctxt, goals) -> solveAndPrint ctxt goals
+    Left err -> error $ "Could not parse input: " ++ err
+
+solveAndPrint :: Ctxt -> [Bdy] -> IO ()
+solveAndPrint ctxt goals = mapM_ (solveAndPrintGoal ctxt) goals
+
+solveAndPrintGoal :: Ctxt -> Bdy -> IO ()
+solveAndPrintGoal ctxt goal = do
+  let res = solve ctxt False goal -- Assuming verbose is always False for this function
+  TIO.putStrLn $ T.pack $ agdaShow goal res

--- a/app/Parser.hs
+++ b/app/Parser.hs
@@ -19,7 +19,7 @@ import CellContext
 
 type IVarName = String
 
-parseId = many1 (letter <|> char '\'')
+parseId = many1 (letter <|> char '\'' <> char '₀' <> char '₁' <> char '₂' <> char '₃' <> char '₄' <> char '₅' <> char '₆' <> char '₇' <> char '₈' <> char '₉')
 
 parseEndpoint :: Parser Endpoint
 parseEndpoint = do
@@ -72,8 +72,13 @@ parseAssign ivs = do
   -- traceShowM t
   return ((i,e) , t)
 
+-- crude,incomplete, but quick way of allowing parentheses around terms
+parseTerm' :: [IVarName] -> Parser Term
+parseTerm' ivs = parseComp ivs <|> parseFill ivs <|> parseApp ivs <|> parsePoint ivs
+
 parseTerm :: [IVarName] -> Parser Term
-parseTerm ivs = parseComp ivs <|> parseFill ivs <|> parseApp ivs <|> parsePoint ivs
+parseTerm ivs = (char '(' >> (parseTerm' ivs >>= \x -> char ')' >> pure x))  <|> parseTerm' ivs
+
 
 parseComp :: [IVarName] -> Parser Term
 parseComp ivs = do

--- a/dedekind.cabal
+++ b/dedekind.cabal
@@ -28,3 +28,17 @@ executable dedekind
                       text >= 2.0.1
     hs-source-dirs:   app
     default-language: Haskell2010
+
+executable dedekind-std
+    import:           warnings
+    main-is:          MainStd.hs
+    other-modules:    Solver , Parser , KanSolver, AgdaShow, CellContext, Contortion, ContortionSolver
+    -- other-extensions:
+    build-depends:    attoparsec >= 0.14.4,
+                      base >=4.15.0.0,
+                      containers >= 0.6.6,
+                      mtl >= 2.2.2,
+                      optparse-applicative >= 0.18.1.0,
+                      text >= 2.0.1
+    hs-source-dirs:   app
+    default-language: Haskell2010


### PR DESCRIPTION
Not sure if this is worth merging, but leaving it here anyway :)

added another executablle, which just accept input on stdin, and print solution to stdout, helping wiht integration with agda.

For this to work, it requires following PR's merged to Agda [#7287](https://github.com/agda/agda/pull/7287), [#6629](https://github.com/agda/agda/pull/6629) 
(here is [my branch](https://github.com/marcinjangrzybowski/agda/tree/cub-reflection-fix-with-surface-parse) incorporating thosoe changes into latest version of agda)

on the cubical library side, all necessary machinery is in this branch:
https://github.com/marcinjangrzybowski/cubical/tree/cubcial-reflection-leaner
intergation is in [Dedekind.agda](https://github.com/marcinjangrzybowski/cubical/blob/cubcial-reflection-leaner/Cubical/Tactics/PathSolver/Dedekind.agda)
(working on PR to cubical-agda with all of this)

dedekind-std must be added to list of trusted executables in agda (Reflection section in agda docs have details of this),
to ensure that dedekind-std is in $Path, cabal install was sufficient on my machine.
